### PR TITLE
Additions to allocations enforcement

### DIFF
--- a/api/v2/serializers/details/instance.py
+++ b/api/v2/serializers/details/instance.py
@@ -60,7 +60,7 @@ class InstanceSerializer(serializers.HyperlinkedModelSerializer):
         return serializer.data
 
     def get_image(self, obj):
-        if obj.source.is_volume():
+        if not obj.source.is_machine():
             return {}
         image_uuid = obj.application_uuid()
         image = Image.objects.get(uuid=image_uuid)
@@ -74,7 +74,7 @@ class InstanceSerializer(serializers.HyperlinkedModelSerializer):
         return obj.ip_address
 
     def get_version(self, obj):
-        if obj.source.is_volume():
+        if not obj.source.is_machine():
             return {}
         version = obj.source.providermachine.application_version
         serializer = ImageVersionSummarySerializer(

--- a/api/v2/serializers/details/instance.py
+++ b/api/v2/serializers/details/instance.py
@@ -60,7 +60,7 @@ class InstanceSerializer(serializers.HyperlinkedModelSerializer):
         return serializer.data
 
     def get_image(self, obj):
-        if not obj.source.is_machine():
+        if obj.source.is_volume():
             return {}
         image_uuid = obj.application_uuid()
         image = Image.objects.get(uuid=image_uuid)
@@ -74,7 +74,7 @@ class InstanceSerializer(serializers.HyperlinkedModelSerializer):
         return obj.ip_address
 
     def get_version(self, obj):
-        if not obj.source.is_machine():
+        if obj.source.is_volume():
             return {}
         version = obj.source.providermachine.application_version
         serializer = ImageVersionSummarySerializer(

--- a/core/models/allocation_source.py
+++ b/core/models/allocation_source.py
@@ -49,7 +49,7 @@ class AllocationSource(models.Model):
                     "The structure of settings.SPECIAL_ALLOCATION_SOURCES "
                     "has changed! Verify your settings are correct and/or "
                     "change the lines of code above.")
-            last_snapshot = self.user_allocation_snapshots.filter(user__username='test-sgregory').order_by('-updated').last()
+            last_snapshot = self.user_allocation_snapshots.get(user=user)
         else:
             compute_allowed = self.compute_allowed
             last_snapshot = self.snapshot

--- a/core/models/allocation_source.py
+++ b/core/models/allocation_source.py
@@ -105,7 +105,8 @@ class UserAllocationSource(models.Model):
           It is presumed that this table will be *MAINTAINED* regularly via periodic task.
     """
 
-    user = models.ForeignKey("AtmosphereUser")
+    user = models.ForeignKey("AtmosphereUser", related_name="user_allocation_sources")
+    # FIXME: this will not return a QuerySet of AtmosphereUser, it will return a QuerySet of UserAllocationSource.. (Rename related_name?)
     allocation_source = models.ForeignKey(AllocationSource, related_name="users")
 
     def __unicode__(self):

--- a/service/exceptions.py
+++ b/service/exceptions.py
@@ -92,9 +92,10 @@ class OverAllocationError(ServiceException):
     def __init__(self, source_name, amount_exceeded):
         self.overage = amount_exceeded
         self.message = "Time allocation exceeded: "\
-            "Allocation %s is over 100% by "\
+            "Allocation %s is over 100%% by "\
             "%s hours."\
-            % (source_name, self.overage,)
+            % (source_name,
+               self.overage)
         super(OverAllocationError, self).__init__(self.message)
 
     def __str__(self):

--- a/service/instance.py
+++ b/service/instance.py
@@ -26,6 +26,7 @@ from libcloud.common.exceptions import BaseHTTPError  # Move into rtwo.exception
 
 from core.query import only_current
 from core.models.instance_source import InstanceSource
+from core.models import AtmosphereUser
 from core.models.ssh_key import get_user_ssh_keys
 from core.models.application import Application
 from core.models.identity import Identity as CoreIdentity
@@ -1308,9 +1309,13 @@ def _test_for_licensing(esh_machine, identity):
 
 
 def check_allocation(username, allocation_source):
-    (over_allocation, time_diff) = allocation_source.check_over_allocation()
-    if over_allocation and settings.ENFORCING:
-        raise OverAllocationError(allocation_source.name, time_diff)
+    user = AtmosphereUser.objects.filter(username=username).first()
+    if not user:
+        raise Exception("Username %s does not exist" % username)
+    compute_remaining = allocation_source.time_remaining(user)
+    over_allocation = compute_remaining < 0
+    if over_allocation:
+        raise OverAllocationError(allocation_source.name, abs(compute_remaining))
 
 
 def check_quota(username, identity_uuid, esh_size,

--- a/service/instance.py
+++ b/service/instance.py
@@ -1314,7 +1314,7 @@ def check_allocation(username, allocation_source):
         raise Exception("Username %s does not exist" % username)
     compute_remaining = allocation_source.time_remaining(user)
     over_allocation = compute_remaining < 0
-    if over_allocation:
+    if over_allocation and settings.ENFORCING:
         raise OverAllocationError(allocation_source.name, abs(compute_remaining))
 
 


### PR DESCRIPTION
## Description
- [x] Simplify the logic for calculating remaining time/over allocation, storing all logic in AllocationSource
- [x] Test and verify that allocations are enforced on the backend and new instances cannot be launched, when the user has exhausted their allocation.
- [x] Change 'related_name' for user, Include a note about 'related_name' for allocation_source
